### PR TITLE
merge upstream https://github.com/ublox-rs/ublox/pull/24

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,9 +40,10 @@ jobs:
     strategy:
       matrix:
         feature-args:
-          - --all-features
-          - --no-default-features --features alloc
-          - --no-default-features
+          - --features "alloc std ubx_series8" # - --all-features
+          - --no-default-features --features "alloc ubx_series8" 
+          - --no-default-features --features ubx_series8
+          - --no-default-features --features ubx_series9
     steps:
       - uses: actions/checkout@v4
       - name: Setup toolchain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1] - 2025-xx-xx
+### Added
+- [[#27](https://github.com/andrei-ng/u-blox.rs/pull/27)] Merge [ublox-rs/ublox/pull/24](https://github.com/ublox-rs/ublox/pull/24) PR that adds `UBX-NAV-RELPOSNED` into this repository.
+    - remove duplicate package definition `MgaGpsEph`
+    - add features flags to differentiate between uBlox Series 8 and uBlox Series 9 devices; As  `UBX-NAV-RELPOSNED` has different lengths depending on the protocol /series.

--- a/ublox/Cargo.toml
+++ b/ublox/Cargo.toml
@@ -11,8 +11,11 @@ version = "0.0.1"
 
 [features]
 alloc = []
-default = ["std", "serde"]
+default = ["std", "serde", "proto_series8"]
 std = []
+
+proto_series8 = []
+proto_series9 = []
 
 [dependencies]
 bitflags = "2.3"

--- a/ublox/Cargo.toml
+++ b/ublox/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
-authors = ["Lane Kolbly <lane@rscheme.org>"]
+authors = [
+    "Andrei Gherghescu <andrei-ng@protonmail.com>",
+    "Lane Kolbly <lane@rscheme.org>",
+]
 description = "A crate to communicate with u-blox GPS devices using the UBX protocol"
 edition = "2021"
 license = "MIT"
@@ -11,11 +14,11 @@ version = "0.0.1"
 
 [features]
 alloc = []
-default = ["std", "serde", "proto_series8"]
+default = ["std", "serde", "ubx_series8"]
 std = []
 
-proto_series8 = []
-proto_series9 = []
+ubx_series8 = []
+ubx_series9 = []
 
 [dependencies]
 bitflags = "2.3"

--- a/ublox/build.rs
+++ b/ublox/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    #[cfg(all(feature = "ubx_series8", feature = "ubx_series9"))]
+    compile_error!(
+        r#"The "ubx_series8" and "ubx_series9" features are mutually exclusive and cannot be activated at the same time. Please disable one or the other."#
+    );
+}

--- a/ublox/src/lib.rs
+++ b/ublox/src/lib.rs
@@ -81,4 +81,5 @@ pub use crate::{
 
 mod error;
 mod parser;
+#[cfg(any(feature = "ubx_series8", feature = "ubx_series9"))]
 mod ubx_packets;

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -426,7 +426,7 @@ struct NavStatus {
     uptime_ms: u32,
 }
 
-#[cfg(feature = "proto_series8")]
+#[cfg(feature = "ubx_series8")]
 #[ubx_packet_recv]
 #[ubx(class = 0x01, id = 0x3c, fixed_payload_len = 40)]
 struct NavRelPosNed {
@@ -450,7 +450,7 @@ struct NavRelPosNed {
     flags: u32,
 }
 
-#[cfg(feature = "proto_series9")]
+#[cfg(feature = "ubx_series9")]
 #[ubx_packet_recv]
 #[ubx(class = 0x01, id = 0x3c, fixed_payload_len = 64)]
 struct NavRelPosNed {
@@ -531,12 +531,12 @@ impl NavRelPosNedFlags {
         (self.0 >> 7) & 0x1 != 0
     }
 
-    #[cfg(feature = "proto_series9")]
+    #[cfg(feature = "ubx_series9")]
     pub fn rel_pos_heading_valid(&self) -> bool {
         (self.0 >> 8) & 0x1 != 0
     }
 
-    #[cfg(feature = "proto_series9")]
+    #[cfg(feature = "ubx_series9")]
     pub fn rel_pos_normalized(&self) -> bool {
         (self.0 >> 9) & 0x1 != 0
     }
@@ -558,7 +558,7 @@ impl fmt::Debug for NavRelPosNedFlags {
             .field("ref_pos_miss", &self.ref_pos_miss())
             .field("ref_obs_miss", &self.ref_obs_miss());
 
-        #[cfg(feature = "proto_series9")]
+        #[cfg(feature = "ubx_series9")]
         dbg_struct
             .field("rel_pos_heading_valid", &self.rel_pos_heading_valid())
             .field("rel_pos_normalized", &self.rel_pos_normalized());

--- a/ublox_derive/Cargo.toml
+++ b/ublox_derive/Cargo.toml
@@ -7,6 +7,7 @@ name = "ublox_derive"
 publish = false
 version = "0.0.1"
 
+
 [lib]
 proc-macro = true
 

--- a/ublox_derive/Cargo.toml
+++ b/ublox_derive/Cargo.toml
@@ -7,7 +7,6 @@ name = "ublox_derive"
 publish = false
 version = "0.0.1"
 
-
 [lib]
 proc-macro = true
 


### PR DESCRIPTION
Merge [ublox-rs/ublox/pull/24](https://github.com/ublox-rs/ublox/pull/24) PR that adds UBX-NAV-RELPOSNED into this repository.

 - remove duplicate package definition MgaGpsEph
 - add features flags to differentiate between uBlox Series 8 and uBlox Series 9 devices; As UBX-NAV-RELPOSNED has different lengths depending on the protocol /series.

Closes #30 